### PR TITLE
Re-enable precompilation with proper cfunction handling

### DIFF
--- a/src/FLAC.jl
+++ b/src/FLAC.jl
@@ -1,18 +1,16 @@
-#__precompile__()
+__precompile__()
 
 module FLAC
 
 using FileIO
 
-export
-       StreamMetaData,
+export StreamMetaData,
        InfoMetaData,
        VorbisCommentMetaData,
        PaddingMetaData,
        ApplicationMetaData,
        SeekTableMetaData,
        CueSheetMetaData,
-
        StreamDecoderPtr,
        StreamEncoderPtr,
        initfile!,
@@ -30,5 +28,10 @@ include("metadata.jl")
 include("format.jl")
 include("decoder.jl")
 include("encoder.jl")
+
+function __init__()
+    init_decoder_cfunctions()
+    init_encoder_cfunctions()
+end
 
 end # module

--- a/src/encoder.jl
+++ b/src/encoder.jl
@@ -103,8 +103,6 @@ function pcallback(en::Ptr{Void},bytesw::Int64,samplesw::Int64,
     nothing
 end
 
-const pcallback_c = cfunction(pcallback, Void, (Ptr{Void},Int64,Int64,Cint,Cint,Ptr{Void}))
-
 """
 ### init_file
 
@@ -169,4 +167,10 @@ function save{T<:Real}(f::File{format"FLAC"}, data::Array{T,2}, samplerate; bits
     process_interleaved(encoder, data_t[end-rem(num_samples,blocksize)+1:end])
     finish(encoder)
     return nothing
+end
+
+# Calculate cfunction versions of all our callbacks once, at runtime, as is necessary with cfunction's
+pcallback_c = Ptr{Void}(C_NULL)
+function init_encoder_cfunctions()
+    global pcallback_c = cfunction(pcallback, Void, (Ptr{Void},Int64,Int64,Cint,Cint,Ptr{Void}))
 end


### PR DESCRIPTION
`cfunction`s need to be explicitly initialized inside of `__init__()` at runtime, otherwise they are all equal to `C_NULL`, which makes the decoder very unhappy.