### PR TITLE
Add `FLACDecoder` type that simplified seeking and streaming

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.5
 BinDeps
 FileIO
+@osx Homebrew

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.5
 BinDeps
 FileIO
 @osx Homebrew
+@windows WinRPM

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
   - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)
   - C:\projects\julia\bin\julia -F -e "versioninfo();
-      Pkg.clone(pwd(), \"Example\"); Pkg.build(\"FLAC\")"
+      Pkg.clone(pwd(), \"FLAC\"); Pkg.build(\"FLAC\")"
 
 test_script:
   - C:\projects\julia\bin\julia -e "Pkg.test(\"FLAC\")"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,41 @@
+environment:
+  matrix:
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+
+branches:
+  only:
+    - master
+    - /release-.*/
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
+install:
+# If there's a newer build queued for the same PR, cancel this one
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+        throw "There are newer queued builds for this pull request, failing early." }
+# Download most recent Julia Windows binary
+  - ps: (new-object net.webclient).DownloadFile(
+        $("http://s3.amazonaws.com/"+$env:JULIAVERSION),
+        "C:\projects\julia-binary.exe")
+# Run installer silently, output to C:\projects\julia
+  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+
+build_script:
+# Need to convert from shallow to complete for Pkg.clone to work
+  - IF EXIST .git\shallow (git fetch --unshallow)
+  - C:\projects\julia\bin\julia -F -e "versioninfo();
+      Pkg.clone(pwd(), \"Example\"); Pkg.build(\"FLAC\")"
+
+test_script:
+  - C:\projects\julia\bin\julia -e "Pkg.test(\"FLAC\")"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -13,7 +13,8 @@ provides(AptGet,"libvorbis-dev",libvorbis)
 
 @static if is_apple()
     if Pkg.installed("Homebrew") === nothing
-        error("Homebrew package not installed, please run Pkg.add(\"Homebrew\")")  end
+        error("Homebrew package not installed, please run Pkg.add(\"Homebrew\")")
+    end
     using Homebrew
     provides( Homebrew.HB, "flac", libflac, os = :Darwin )
     provides( Homebrew.HB, "libogg", libogg, os = :Darwin )

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,22 +3,26 @@ using Compat
 
 @BinDeps.setup
 
-libflac = library_dependency("libflac",aliases=["libFLAC"])
-libogg = library_dependency("libogg")
-libvorbis = library_dependency("libvorbis")
+libflac = library_dependency("libflac",aliases=["libFLAC","libFLAC-8"])
+libogg = library_dependency("libogg",aliases=["libogg-0"])
+libvorbis = library_dependency("libvorbis",aliases=["libvorbis-0"])
 
 provides(AptGet,"libflac-dev",libflac)
 provides(AptGet,"libogg-dev",libogg)
 provides(AptGet,"libvorbis-dev",libvorbis)
 
 @static if is_apple()
-    if Pkg.installed("Homebrew") === nothing
-        error("Homebrew package not installed, please run Pkg.add(\"Homebrew\")")
-    end
     using Homebrew
     provides( Homebrew.HB, "flac", libflac, os = :Darwin )
     provides( Homebrew.HB, "libogg", libogg, os = :Darwin )
     provides( Homebrew.HB, "libvorbis", libvorbis, os = :Darwin )
+end
+
+@static if is_windows()
+    using WinRPM
+    provides(WinRPM.RPM, "flac", libflac, os = :Windows )
+    provides(WinRPM.RPM, "libogg0", libogg, os = :Windows )
+    provides(WinRPM.RPM, "libvorbis0", libvorbis, os = :Windows )
 end
 
 @BinDeps.install Dict(:libflac => :libflac,:libogg => :libogg)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -11,7 +11,7 @@ provides(AptGet,"libflac-dev",libflac)
 provides(AptGet,"libogg-dev",libogg)
 provides(AptGet,"libvorbis-dev",libvorbis)
 
-@static if is_apple() begin
+@static if is_apple()
     if Pkg.installed("Homebrew") === nothing
         error("Homebrew package not installed, please run Pkg.add(\"Homebrew\")")  end
     using Homebrew

--- a/src/FLAC.jl
+++ b/src/FLAC.jl
@@ -14,8 +14,13 @@ export StreamMetaData,
        StreamDecoderPtr,
        StreamEncoderPtr,
        initfile!,
-       load,
-       save
+       FLACDecoder,
+       seek,
+       read,
+       size,
+       length
+
+import Base: read, seek, size, length
 
 const depfile = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
 if isfile(depfile)

--- a/src/decoder.jl
+++ b/src/decoder.jl
@@ -177,11 +177,31 @@ function initfile!(dd::StreamDecoderPtr, fnm::String; wcallback=debug_wcallback_
     dd
 end
 
-process_single(dd::StreamDecoderPtr) = ccall((:FLAC__stream_decoder_process_single,libflac), Bool,(Ptr{Void},), dd)
-process_metadata(dd::StreamDecoderPtr) = ccall((:FLAC__stream_decoder_process_until_end_of_metadata,libflac), Bool,(Ptr{Void},), dd)
-process_stream(dd::StreamDecoderPtr) = ccall((:FLAC__stream_decoder_process_until_end_of_stream,libflac), Bool,(Ptr{Void},), dd)
-seek_absolute(dd::StreamDecoderPtr, offset::UInt64) = ccall((:FLAC__stream_decoder_seek_absolute,libflac), Bool,(Ptr{Void},UInt64), dd, offset)
-flush(dd::StreamDecoderPtr) = ccall((:FLAC__stream_decoder_flush,libflac), Bool,(Ptr{Void},), dd)
+function process_single(dd::StreamDecoderPtr)
+    disable_sigint() do
+        ccall((:FLAC__stream_decoder_process_single,libflac), Bool, (Ptr{Void},), dd)
+    end
+end
+function process_metadata(dd::StreamDecoderPtr)
+    disable_sigint() do
+        ccall((:FLAC__stream_decoder_process_until_end_of_metadata,libflac), Bool, (Ptr{Void},), dd)
+    end
+end
+function process_stream(dd::StreamDecoderPtr)
+    disable_sigint() do
+        ccall((:FLAC__stream_decoder_process_until_end_of_stream,libflac), Bool, (Ptr{Void},), dd)
+    end
+end
+function seek_absolute(dd::StreamDecoderPtr, offset::UInt64)
+    disable_sigint() do
+        ccall((:FLAC__stream_decoder_seek_absolute,libflac), Bool, (Ptr{Void},UInt64), dd, offset)
+    end
+end
+function flush(dd::StreamDecoderPtr)
+    disable_sigint() do
+        ccall((:FLAC__stream_decoder_flush,libflac), Bool, (Ptr{Void},), dd)
+    end
+end
 
 function saving_mcallback(d::Ptr{Void}, mp::Ptr{Void}, client::Ptr{Void})
     typ = unsafe_load(reinterpret(Ptr{MetaDataType}, mp))

--- a/src/decoder.jl
+++ b/src/decoder.jl
@@ -262,11 +262,11 @@ type FLACDecoder
 end
 
 """
-`read(f::FLACDecoder, num_samples::Int)`
+`read(f::FLACDecoder, num_samples::Integer)`
 
 Read up to the specified number of samples from the given FLACDecoder,
 """
-function read(f::FLACDecoder, num_samples::Int)
+function read{T<:Integer}(f::FLACDecoder, num_samples::T)
     # Allocate memory to hold all the read data
     data = Array{Float32,2}(num_samples, f.metadata.channels)
     data_read = 0
@@ -307,11 +307,11 @@ function read(f::FLACDecoder, num_samples::Int)
 end
 
 """
-`seek(f::FLACDecoder, offset::Int)`
+`seek(f::FLACDecoder, offset::Int64)`
 
 Perform an absolute seek within the given FLAC stream
 """
-function seek(f::FLACDecoder, offset::Int)
+function seek{T<:Integer}(f::FLACDecoder, offset::T)
     if !seek_absolute(f.dec, UInt64(offset))
         ArgumentError("Could not seek to offset $offset")
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,69 +3,72 @@ using WAV
 using Base.Test
 using FLAC
 
-testdir = dirname(@__FILE__)
 
-# Start by loading our ground truth data from the .wav
-# This data generated as sin(linspace(0,4410*2*pi,44100)[1:441])
-check_data, check_fs = wavread(joinpath(testdir, "4410hz.wav"))
+@testset "FLAC" begin
+    testdir = dirname(@__FILE__)
 
-# Load flac'ed version of 4410hz.wav (generated with `ffmpeg -i 4410hz.wav -acodec flac 4410hz.flac`)
-data, fs = load(joinpath(testdir, "4410hz.flac"))
-@test fs == check_fs
-@test size(data) == size(check_data)
-@test maximum(abs(check_data - data)) < 1e-6
+    # Start by loading our ground truth data from the .wav
+    # This data generated as sin(linspace(0,4410*2*pi,44100)[1:441])
+    check_data, check_fs = wavread(joinpath(testdir, "4410hz.wav"))
 
-
-# Test against 16-bit FLAC file (generated with `ffmpeg -i 4410hz.wav -acodec flac -sample_fmt s16 4410hz_s16.flac`)
-s16_data, s16_fs = load(joinpath(testdir, "4410hz_s16.flac"))
-@test s16_fs == check_fs
-@test size(s16_data) == size(check_data)
-@test maximum(abs(check_data - s16_data)) < 1e-4   # reduced precision due to s16 format
+    # Load flac'ed version of 4410hz.wav (generated with `ffmpeg -i 4410hz.wav -acodec flac 4410hz.flac`)
+    data, fs = load(joinpath(testdir, "4410hz.flac"))
+    @test fs == check_fs
+    @test size(data) == size(check_data)
+    @test maximum(abs(check_data - data)) < 1e-6
 
 
-# Test multichannel FLAC file (left and right channels opposing polarity versions of 4410hz signal)
-stereo_data = load(joinpath(testdir, "stereo.flac"))[1]
-stereo_check_data = wavread(joinpath(testdir, "stereo.wav"))[1]
-@test size(stereo_data) == size(stereo_check_data)
-@test maximum(abs(stereo_data - stereo_check_data)) < 1e-6
-
-# Test FLACDecoder works with chunked reads
-f = FLACDecoder(joinpath(testdir, "4410hz.flac"))
-chunked = Array{Float32,2}(size(f)...)
-chunked[1:100, :] = read(f, 100)
-chunked[101:end, :] = read(f, length(f) - 100)
-@test f.metadata.samplerate == check_fs
-@test size(f) == size(check_data)
-@test maximum(abs(check_data - chunked)) < 1e-6
-
-# Test FLACDecoder seek'ing works
-f = FLACDecoder(joinpath(testdir, "4410hz.flac"))
-seek(f, 100)
-@test maximum(abs(read(f, 100) - check_data[101:200])) < 1e-6
-@test maximum(abs(read(f, 100) - check_data[201:300])) < 1e-6
-seek(f, 0)
-@test maximum(abs(read(f, length(f)) - check_data)) < 1e-6
+    # Test against 16-bit FLAC file (generated with `ffmpeg -i 4410hz.wav -acodec flac -sample_fmt s16 4410hz_s16.flac`)
+    s16_data, s16_fs = load(joinpath(testdir, "4410hz_s16.flac"))
+    @test s16_fs == check_fs
+    @test size(s16_data) == size(check_data)
+    @test maximum(abs(check_data - s16_data)) < 1e-4   # reduced precision due to s16 format
 
 
-# Now that we have confidence our decoder works, let's roundtrip a signal multiple times
-function roundtrip(signal, samplerate; params...)
-    path = joinpath(testdir,"roundtrip.flac")
-    if isfile(path)
+    # Test multichannel FLAC file (left and right channels opposing polarity versions of 4410hz signal)
+    stereo_data = load(joinpath(testdir, "stereo.flac"))[1]
+    stereo_check_data = wavread(joinpath(testdir, "stereo.wav"))[1]
+    @test size(stereo_data) == size(stereo_check_data)
+    @test maximum(abs(stereo_data - stereo_check_data)) < 1e-6
+
+    # Test FLACDecoder works with chunked reads
+    f = FLACDecoder(joinpath(testdir, "4410hz.flac"))
+    chunked = Array{Float32,2}(size(f)...)
+    chunked[1:100, :] = read(f, 100)
+    chunked[101:end, :] = read(f, length(f) - 100)
+    @test f.metadata.samplerate == check_fs
+    @test size(f) == size(check_data)
+    @test maximum(abs(check_data - chunked)) < 1e-6
+
+    # Test FLACDecoder seek'ing works
+    f = FLACDecoder(joinpath(testdir, "4410hz.flac"))
+    seek(f, 100)
+    @test maximum(abs(read(f, 100) - check_data[101:200])) < 1e-6
+    @test maximum(abs(read(f, 100) - check_data[201:300])) < 1e-6
+    seek(f, 0)
+    @test maximum(abs(read(f, length(f)) - check_data)) < 1e-6
+
+
+    # Now that we have confidence our decoder works, let's roundtrip a signal multiple times
+    function roundtrip(signal, samplerate; params...)
+        path = joinpath(testdir,"roundtrip.flac")
+        if isfile(path)
+            gc()
+            rm(path)
+        end
+        save(path, signal, samplerate; params...)
+        recon_signal, recon_fs = load(path)
+
+        @test recon_fs == samplerate
+        @test size(recon_signal) == size(signal)
+        #show(recon_signal - signal)
+        @test maximum(abs(recon_signal - signal)) < 1e-4
         gc()
         rm(path)
     end
-    save(path, signal, samplerate; params...)
-    recon_signal, recon_fs = load(path)
 
-    @test recon_fs == samplerate
-    @test size(recon_signal) == size(signal)
-    #show(recon_signal - signal)
-    @test maximum(abs(recon_signal - signal)) < 1e-4
-    gc()
-    rm(path)
+    test_signal = sin(linspace(0,4410*2*pi,44100)[1:44100])''*.999
+    roundtrip(test_signal, 44100)
+    roundtrip(test_signal, 44100, bits_per_sample=16)
+    roundtrip(test_signal, 48000, compression_level=8)
 end
-
-test_signal = sin(linspace(0,4410*2*pi,44100)[1:44100])''*.999
-roundtrip(test_signal, 44100)
-roundtrip(test_signal, 44100, bits_per_sample=16)
-roundtrip(test_signal, 48000, compression_level=8)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,6 +51,7 @@ seek(f, 0)
 function roundtrip(signal, samplerate; params...)
     path = joinpath(testdir,"roundtrip.flac")
     if isfile(path)
+        gc()
         rm(path)
     end
     save(path, signal, samplerate; params...)
@@ -60,6 +61,7 @@ function roundtrip(signal, samplerate; params...)
     @test size(recon_signal) == size(signal)
     #show(recon_signal - signal)
     @test maximum(abs(recon_signal - signal)) < 1e-4
+    gc()
     rm(path)
 end
 


### PR DESCRIPTION
@dmbates I'd like to get your feedback on this.

I have very large (hundreds of MB) .flac files that are paired with annotation files, denoting segments within the .flac file that are of interest to me.  I'd like to avoid decompressing the entire .flac file into memory, then snipping out the pieces that I'm interested in.  To that end, I've revamped the decoder interface of FLAC.jl a bit in this PR, to make this kind of operation a little more natural.  Here's what I've done:

* Created a new type, `FLACDecoder`, which immediately parses the metadata of a FLAC file out, but nothing else.  The `FLACDecoder` has `read()`, `seek()`, `length()` and `size()` methods to make working with it as easy as possible.  It has internal state enough to work with a single frame of FLAC data at a time.

* The `read()` method reads in frame after frame until the desired number of samples have been input.  To read the entire file, one simply uses `read(f, length(f))`.

* The `seek()` method uses the builtin FLAC seeking machinery to jump to the desired absolute sample offset.

* The `load()` function has been altered to use this new machinery.  I'm not aware of loading large files in being significantly slower in this version of the code, despite the data being copied twice instead of once (once from FLAC -> `FLACDecoder` frame cache, once from `FLACDecoder` frame cache to large contiguous array that is returned to the user) so I'm happy to report that the decoding process is still CPU-bound, as opposed to memory-bound.

Anyway, I thought I would get your feedback on whether you like this approach or whether you think there's a better way to do this.