### PR TITLE
Fix 0.6 depwarns and ambiguities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.5
+Compat
 BinDeps
 FileIO
 @osx Homebrew

--- a/src/FLAC.jl
+++ b/src/FLAC.jl
@@ -3,6 +3,7 @@ __precompile__()
 module FLAC
 
 using FileIO
+using Compat
 
 export StreamMetaData,
        InfoMetaData,

--- a/src/decoder.jl
+++ b/src/decoder.jl
@@ -19,8 +19,8 @@ Base.unsafe_convert(::Type{Ptr{Void}}, en::StreamDecoderPtr) = en.v
 
 for (nm,typ) in (("ogg_serial_number", :Clong),
                  ("md5_checking", :Bool),
-                 ("metadata_respond", :MetadataType),
-                 ("metadata_ignore", :MetadataType))
+                 ("metadata_respond", :MetaDataType),
+                 ("metadata_ignore", :MetaDataType))
     @eval begin
         function $(Symbol(string("set_", nm)))(dd::StreamDecoderPtr, val)
             ccall(($(string("FLAC__stream_decoder_set_",nm)), libflac), Bool,
@@ -71,7 +71,8 @@ get_state_string(dd::StreamDecoderPtr) =
       DecoderMemoryAllocationError,
       DecoderUninitialized)
 
-for (nm,typ) in (("state",:DecoderState),
+
+for (nm,typ) in (("state",:StreamDecoderState),
                  ("md5_checking",:Bool),
                  ("total_samples",:Int64),
                  ("channels",:Cint),
@@ -249,7 +250,7 @@ type FLACDecoder
         dec = StreamDecoderPtr()
 
         # Create initial, empty FLACDecoder object
-        f = new(path, dec, InfoMetaData(), Array{Float32,2}(), 0, 0)
+        f = new(path, dec, InfoMetaData(), Array{Float32,2}(0, 0), 0, 0)
 
         # Open file, process metadata
         initfile!(dec, path, wcallback=buffering_wcallback_c, mcallback=saving_mcallback_c, client_data=pointer_from_objref(f))

--- a/src/encoder.jl
+++ b/src/encoder.jl
@@ -140,8 +140,8 @@ function Base.show(io::IO,en::StreamEncoderPtr)
     println()
 end
 
-# Cheat save() implementation for people who want to input a 1d array instead of the proper 2d array
-save{T<:Real}(f::File{format"FLAC"}, data::Array{T,1}, samplerate; kwargs...) = save(f, data'', samplerate; kwargs...)
+# save() implementation for people who want to input a 1d array instead of the proper 2d array
+save{T<:Real}(f::File{format"FLAC"}, data::Array{T,1}, samplerate; kwargs...) = save(f, reshape(data, :, 1), samplerate; kwargs...)
 
 function save{T<:Real}(f::File{format"FLAC"}, data::Array{T,2}, samplerate; bits_per_sample = 24, compression_level = 3)
     encoder = StreamEncoderPtr()

--- a/src/format.jl
+++ b/src/format.jl
@@ -8,7 +8,7 @@
       FrameNumber,
       SampleNumber)
 
-immutable FrameHeader
+@compat immutable FrameHeader
     blocksize::Cuint
     sample_rate::Cuint
     channels::Cuint
@@ -23,7 +23,7 @@ const FrameHeaderSync = 0x00003ffe
 
 const MAX_CHANNELS = 0x00000008
 
-immutable FrameFooter
+@compat immutable FrameFooter
     crc::UInt16
 end
 
@@ -31,18 +31,18 @@ end
       PartitionedRice,
       PartitionedRice2)
 
-immutable PartitionedRiceContents
+@compat immutable PartitionedRiceContents
     parameters::Ptr{Cuint}
     raw_bits::Ptr{Cuint}
     capacity_by_order::Cuint
 end
 
-immutable PartitionedRiceT
+@compat immutable PartitionedRiceT
     order::Cuint
     contents::Ptr{PartitionedRiceContents}
 end
 
-immutable EntropyCodingMethod
+@compat immutable EntropyCodingMethod
     typ::EntropyCodingMethodType
     data::PartitionedRiceT
 end
@@ -53,19 +53,19 @@ end
       SubframeFixed,
       SubframeLPC)
 
-abstract Subframe
+@compat abstract type Subframe end
 
-immutable Subframe_Constant <: Subframe
+@compat immutable Subframe_Constant <: Subframe
     value::Int32
 end
 
-immutable Subframe_Verbatim <: Subframe
+@compat immutable Subframe_Verbatim <: Subframe
     data::Ptr{Int32}
 end
 
 const MAX_FIXED_ORDER = 0x00000004
 
-immutable SubFrame_Fixed <: Subframe
+@compat immutable SubFrame_Fixed <: Subframe
     method::EntropyCodingMethod
     order::Cuint
     warmup::NTuple{Int(MAX_FIXED_ORDER),Int32}
@@ -74,7 +74,7 @@ end
 
 const MAX_LPC_ORDER = 0x00000020
 
-immutable SubFrame_LPC <: Subframe
+@compat immutable SubFrame_LPC <: Subframe
     method::EntropyCodingMethod
     order::Cuint
     qlp_coeff_precision::Cuint
@@ -84,13 +84,13 @@ immutable SubFrame_LPC <: Subframe
     residual::Ptr{Int32}
 end
 
-immutable SubFrame{SF <: Subframe}
+@compat immutable SubFrame{SF <: Subframe}
     typ::SubframeType
     data::SF
     wasted_bits::Cuint
 end
 
-immutable Frame
+@compat immutable Frame
     header::FrameHeader
     subframes::NTuple{Int(MAX_CHANNELS),SubFrame}
     footer::FrameFooter

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -6,7 +6,7 @@ Each type of metadata object contains an indicator
 of its `typ`, an indicator of whether this is the
 last metadata block and its length, in bytes.
 """
-abstract StreamMetaData
+@compat abstract type StreamMetaData end
 
 @enum(MetaDataType,
       Info,
@@ -46,7 +46,7 @@ A block containing information on the stream including
 `samplerate`, `channels`, `bitspersample`, `totalsamples`,
 and `mdsum`.
 """
-type InfoMetaData <: StreamMetaData
+@compat type InfoMetaData <: StreamMetaData
     typ::MetaDataType
     is_last::Cint
     len::Int64
@@ -66,7 +66,7 @@ end
 """
 `len` bytes of padding in the FLAC stream.
 """
-type PaddingMetaData <: StreamMetaData
+@compat type PaddingMetaData <: StreamMetaData
     typ::MetaDataType
     is_last::Cint
     len::Int64
@@ -78,7 +78,7 @@ Application metadata
 
 Not sure what this is for.
 """
-type ApplicationMetaData <: StreamMetaData
+@compat type ApplicationMetaData <: StreamMetaData
     typ::MetaDataType
     is_last::Cint
     len::Int64
@@ -86,7 +86,7 @@ type ApplicationMetaData <: StreamMetaData
     data::Ptr{Void}
 end
 
-immutable SeekPoint
+@compat immutable SeekPoint
     sample_number::Int64
     stream_offset::Int64
     frame_samples::UInt32
@@ -95,7 +95,7 @@ end
 """
 An array of `SeekPoint`s
 """
-type SeekTableMetaData <: StreamMetaData
+@compat type SeekTableMetaData <: StreamMetaData
     typ::MetaDataType
     is_last::Cint
     len::Int64
@@ -110,7 +110,7 @@ A single Vorbis comment.
 Comments are usually key/value pairs of the form
 `ARTIST=Miles Davis`, `YEAR=1965`, etc.
 """
-immutable VorbisCommentEntry
+@compat immutable VorbisCommentEntry
     len::UInt32
     entry::Ptr{UInt8}
 end
@@ -118,7 +118,7 @@ end
 """
 Vorbis comment metadata.  The vendor comment is always present.
 """
-type VorbisCommentMetaData <: StreamMetaData
+@compat type VorbisCommentMetaData <: StreamMetaData
     typ::MetaDataType
     is_last::Cint
     len::Cuint
@@ -130,7 +130,7 @@ end
 """
 A single cue sheet index
 """
-immutable CueSheetIndex
+@compat immutable CueSheetIndex
     offset::UInt64
     number::UInt8
 end
@@ -141,7 +141,7 @@ A single track annotation in a CueSheet.
 I'm not sure about the offsets here.  In the C struct the `typ` and `pre_emphasis` fields
 are single bits.
 """
-immutable CueSheetTrack
+@compat immutable CueSheetTrack
     offset::Int64
     number::UInt8
     isrc::NTuple{13, UInt8}
@@ -159,7 +159,7 @@ Cue sheet meta data.
 
 An array of `CueSheetTrack`s
 """
-type CueSheetMetaData <: StreamMetaData
+@compat type CueSheetMetaData <: StreamMetaData
     typ::MetaDataType
     is_last::Cint
     len::Int64
@@ -170,7 +170,7 @@ type CueSheetMetaData <: StreamMetaData
     tracks::Ptr{CueSheetTrack}
 end
 
-type PictureMetaData <: StreamMetaData
+@compat type PictureMetaData <: StreamMetaData
     typ::MetaDataType
     is_last::Cint
     len::Int64

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,21 +15,21 @@ using FLAC
     data, fs = load(joinpath(testdir, "4410hz.flac"))
     @test fs == check_fs
     @test size(data) == size(check_data)
-    @test maximum(abs(check_data - data)) < 1e-6
+    @test maximum(abs.(check_data - data)) < 1e-6
 
 
     # Test against 16-bit FLAC file (generated with `ffmpeg -i 4410hz.wav -acodec flac -sample_fmt s16 4410hz_s16.flac`)
     s16_data, s16_fs = load(joinpath(testdir, "4410hz_s16.flac"))
     @test s16_fs == check_fs
     @test size(s16_data) == size(check_data)
-    @test maximum(abs(check_data - s16_data)) < 1e-4   # reduced precision due to s16 format
+    @test maximum(abs.(check_data - s16_data)) < 1e-4   # reduced precision due to s16 format
 
 
     # Test multichannel FLAC file (left and right channels opposing polarity versions of 4410hz signal)
     stereo_data = load(joinpath(testdir, "stereo.flac"))[1]
     stereo_check_data = wavread(joinpath(testdir, "stereo.wav"))[1]
     @test size(stereo_data) == size(stereo_check_data)
-    @test maximum(abs(stereo_data - stereo_check_data)) < 1e-6
+    @test maximum(abs.(stereo_data - stereo_check_data)) < 1e-6
 
     # Test FLACDecoder works with chunked reads
     f = FLACDecoder(joinpath(testdir, "4410hz.flac"))
@@ -38,15 +38,15 @@ using FLAC
     chunked[101:end, :] = read(f, length(f) - 100)
     @test f.metadata.samplerate == check_fs
     @test size(f) == size(check_data)
-    @test maximum(abs(check_data - chunked)) < 1e-6
+    @test maximum(abs.(check_data - chunked)) < 1e-6
 
     # Test FLACDecoder seek'ing works
     f = FLACDecoder(joinpath(testdir, "4410hz.flac"))
     seek(f, 100)
-    @test maximum(abs(read(f, 100) - check_data[101:200])) < 1e-6
-    @test maximum(abs(read(f, 100) - check_data[201:300])) < 1e-6
+    @test maximum(abs.(read(f, 100) - check_data[101:200])) < 1e-6
+    @test maximum(abs.(read(f, 100) - check_data[201:300])) < 1e-6
     seek(f, 0)
-    @test maximum(abs(read(f, length(f)) - check_data)) < 1e-6
+    @test maximum(abs.(read(f, length(f)) - check_data)) < 1e-6
 
 
     # Now that we have confidence our decoder works, let's roundtrip a signal multiple times
@@ -59,15 +59,22 @@ using FLAC
         save(path, signal, samplerate; params...)
         recon_signal, recon_fs = load(path)
 
+        # Squeeze the signals to avoid Julia 0.5/0.6 differences
+        if ndims(recon_signal) > 1 
+            recon_signal = squeeze(recon_signal, 2)
+        end
+        if ndims(signal) > 1
+            signal = squeeze(signal, 2)
+        end
+
         @test recon_fs == samplerate
         @test size(recon_signal) == size(signal)
-        #show(recon_signal - signal)
-        @test maximum(abs(recon_signal - signal)) < 1e-4
+        @test maximum(abs.(recon_signal - signal)) < 1e-4
         gc()
         rm(path)
     end
 
-    test_signal = sin(linspace(0,4410*2*pi,44100)[1:44100])''*.999
+    test_signal = sin.(linspace(0,4410*2*pi,44100)[1:44100])''*.999
     roundtrip(test_signal, 44100)
     roundtrip(test_signal, 44100, bits_per_sample=16)
     roundtrip(test_signal, 48000, compression_level=8)


### PR DESCRIPTION
Let's ensure this works on 0.5 and 0.6 before merging.