### PR TITLE
`round()` -> `round.()` to fix depwarns, bump to 0.6 minimum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - 0.6
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.6
 Compat 0.17
 BinDeps
 FileIO

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/encoder.jl
+++ b/src/encoder.jl
@@ -169,7 +169,7 @@ function save{T<:Real}(f::File{format"FLAC"}, data::Array{T,2}, samplerate; bits
     end
 
     # Shove interleaved samples into the encoder by transposing, and convert to Int32
-    data_t = round(Int32, data'*2^(bits_per_sample - 1))
+    data_t = round.(Int32, data'*2^(bits_per_sample - 1))
     blocksize = get_blocksize(encoder)
     for idx in 1:div(num_samples, blocksize)
         block_idxs = ((idx - 1) * blocksize + 1):(idx * blocksize)


### PR DESCRIPTION
Note this also bumps the minimum Julia version to 0.6